### PR TITLE
Add CI workflow to run tests, linter, and type checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+  typecheck:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+  test:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run test

--- a/src/utils/fromA1.spec.ts
+++ b/src/utils/fromA1.spec.ts
@@ -70,7 +70,7 @@ describe('fromA1', () => {
     });
   });
 
-  describe.only('robustness / formatting', () => {
+  describe('robustness / formatting', () => {
     const MAX_ROW = 1048575;
     const MAX_COL = 16383;
 


### PR DESCRIPTION
Runs the three scripts from `package.json` on GitHub Actions using Ubuntu and Node 24. (Node 22.7 is the minimum for the test script because it uses `node --experimental-transform-types`.) Runs for PRs and merges to `master`.

I tested this locally with [Act](https://github.com/nektos/act) and spotted the `.only` modifier that was accidentally added in 458ffd0cb8c3.