### PR TITLE
Change cli build to ESM -- jsfkit/utils is ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "numfmt": "~3.2.6"
       },
       "bin": {
-        "xlsx-convert": "dist/cli.cjs"
+        "xlsx-convert": "dist/cli.js"
       },
       "devDependencies": {
         "@borgar/eslint-config": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     },
     {
       "entry": "src/cli.ts",
-      "platform": "node",
-      "format": "cjs"
+      "platform": "node"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   },
   "bin": {
-    "xlsx-convert": "./dist/cli.js"
+    "xlsx-convert": "./dist/cli.mjs"
   },
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   },
   "bin": {
-    "xlsx-convert": "./dist/cli.cjs"
+    "xlsx-convert": "./dist/cli.js"
   },
   "directories": {
     "test": "tests"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,18 +7,21 @@ import type { Workbook } from '@jsfkit/types';
 type CliOptions = {
   input?: string;
   output?: string;
+  cellFormulas?: boolean;
 };
 
 function printUsage (): void {
   const usage = [
-    'Usage: xlsx-convert <input> [-o <output>]',
+    'Usage: xlsx-convert <input> [-o <output>] [-f]',
     '',
     'Converts .xlsx to JSON via convertBinary,',
     'and .csv to JSON via convertCSV.',
     '',
     'Options:',
-    '  -o, --output <file>  Write JSON output to a file (defaults to stdout)',
-    '  -h, --help           Show this help text',
+    '  -o, --output <file>    Write JSON output to a file (defaults to stdout)',
+    '  -f, --cell-formulas    Emit A1 formulas inline on cells instead of R1C1',
+    '                         index references into a shared formula list',
+    '  -h, --help             Show this help text',
   ].join('\n');
   process.stdout.write(usage + '\n');
 }
@@ -37,6 +40,10 @@ function parseArgs (args: string[]): CliOptions | null {
       }
       opts.output = next;
       i++;
+      continue;
+    }
+    if (arg === '-f' || arg === '--cell-formulas') {
+      opts.cellFormulas = true;
       continue;
     }
     if (arg.startsWith('-')) {
@@ -72,7 +79,7 @@ async function main (): Promise<void> {
   }
   else if (ext === '.xlsx' || ext === '.xlsm') {
     const bin = await readFile(input);
-    workbook = await convertBinary(bin, input);
+    workbook = await convertBinary(bin, input, { cellFormulas: !!parsed.cellFormulas });
   }
   else {
     throw new Error('Unsupported file type. Expected .xlsx, .xlsm, or .csv.');


### PR DESCRIPTION
There's no real need or special reason to use CJS for the CLI anyway, it's a CLI script -- I think I'm slowly beginning to understand some of this JS build jargon.