### PR TITLE
parseDataFields: elide default baseField/baseItem on parse

### DIFF
--- a/src/handler/pivotTable.spec.ts
+++ b/src/handler/pivotTable.spec.ts
@@ -247,6 +247,11 @@ describe('handlerPivotTable', () => {
   });
 
   it('should parse data fields with subtotal, showDataAs, baseField/baseItem', () => {
+    // Default `baseField`/`baseItem` (both `0`) are elided from the parsed
+    // JSF --- Excel always emits the explicit `0` on dataField, so preserving
+    // the literal would force round-trip producers to either emit the
+    // attribute unconditionally or set it explicitly to `0` on every input.
+    // Non-default values still round-trip; covered by the next test.
     const xml = `<pivotTableDefinition name="PT1" cacheId="0">
       <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
       <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
@@ -261,9 +266,24 @@ describe('handlerPivotTable', () => {
       fieldIndex: 0,
       subtotal: 'sum',
       showDataAs: 'percentOfTotal',
-      baseField: 0,
-      baseItem: 0,
     });
+    expect(pt.dataFields![0]).not.toHaveProperty('baseField');
+    expect(pt.dataFields![0]).not.toHaveProperty('baseItem');
+  });
+
+  it('should parse non-default baseField/baseItem verbatim', () => {
+    // Only the OOXML default value (`0`) is elided; explicit non-defaults
+    // are still preserved so they round-trip cleanly.
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="1">
+        <dataField name="Diff" fld="0" showDataAs="difference" baseField="2" baseItem="3"/>
+      </dataFields>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.dataFields![0]).toMatchObject({ baseField: 2, baseItem: 3 });
   });
 
   it('should parse page fields with selectedItem', () => {

--- a/src/handler/pivotTable.spec.ts
+++ b/src/handler/pivotTable.spec.ts
@@ -247,11 +247,9 @@ describe('handlerPivotTable', () => {
   });
 
   it('should parse data fields with subtotal, showDataAs, baseField/baseItem', () => {
-    // Default `baseField`/`baseItem` (both `0`) are elided from the parsed
-    // JSF --- Excel always emits the explicit `0` on dataField, so preserving
-    // the literal would force round-trip producers to either emit the
-    // attribute unconditionally or set it explicitly to `0` on every input.
-    // Non-default values still round-trip; covered by the next test.
+    // JSF stores non-default values; the OOXML-default `0` on
+    // `baseField`/`baseItem` is elided on parse. Non-default values still
+    // round-trip --- covered by the next test.
     const xml = `<pivotTableDefinition name="PT1" cacheId="0">
       <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
       <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>

--- a/src/handler/pivotTables/parseDataFields.ts
+++ b/src/handler/pivotTables/parseDataFields.ts
@@ -49,12 +49,9 @@ export function parseDataFields (root: Element, numFmts?: NumFmtLookup): PivotDa
     addProp(dataField, 'name', attr(df, 'name'));
     addProp(dataField, 'subtotal', parseEnum(attr(df, 'subtotal'), DATA_FIELD_AGGREGATIONS));
     addProp(dataField, 'showDataAs', parseEnum(attr(df, 'showDataAs'), SHOW_DATA_AS_VALUES));
-    // `baseField` and `baseItem` default to `0` per OOXML; Excel always
-    // emits them explicitly (even when 0) on the dataField. Elide the
-    // default in the parsed JSF so it stays canonically minimal, and so
-    // it round-trips cleanly through emitters that also emit the
-    // explicit defaults (e.g. jsf2xlsx writes `baseField="0"` /
-    // `baseItem="0"` unconditionally).
+    // JSF stores non-default values; defaults are implicit. `baseField`
+    // and `baseItem` default to `0` per OOXML, so the explicit `0` Excel
+    // emits is elided here to keep the parsed JSF canonically minimal.
     addProp(dataField, 'baseField', numAttr(df, 'baseField'), 0);
     addProp(dataField, 'baseItem', numAttr(df, 'baseItem'), 0);
     addProp(dataField, 'numFmt', resolveNumFmt(df, numFmts));

--- a/src/handler/pivotTables/parseDataFields.ts
+++ b/src/handler/pivotTables/parseDataFields.ts
@@ -49,8 +49,14 @@ export function parseDataFields (root: Element, numFmts?: NumFmtLookup): PivotDa
     addProp(dataField, 'name', attr(df, 'name'));
     addProp(dataField, 'subtotal', parseEnum(attr(df, 'subtotal'), DATA_FIELD_AGGREGATIONS));
     addProp(dataField, 'showDataAs', parseEnum(attr(df, 'showDataAs'), SHOW_DATA_AS_VALUES));
-    addProp(dataField, 'baseField', numAttr(df, 'baseField'));
-    addProp(dataField, 'baseItem', numAttr(df, 'baseItem'));
+    // `baseField` and `baseItem` default to `0` per OOXML; Excel always
+    // emits them explicitly (even when 0) on the dataField. Elide the
+    // default in the parsed JSF so it stays canonically minimal, and so
+    // it round-trips cleanly through emitters that also emit the
+    // explicit defaults (e.g. jsf2xlsx writes `baseField="0"` /
+    // `baseItem="0"` unconditionally).
+    addProp(dataField, 'baseField', numAttr(df, 'baseField'), 0);
+    addProp(dataField, 'baseItem', numAttr(df, 'baseItem'), 0);
     addProp(dataField, 'numFmt', resolveNumFmt(df, numFmts));
     dataFields.push(dataField);
   }

--- a/tests/excel/pivot-table.xlsx.json
+++ b/tests/excel/pivot-table.xlsx.json
@@ -250,9 +250,7 @@
         {
           "fieldIndex": 3,
           "name": "Average of Salary",
-          "subtotal": "average",
-          "baseField": 0,
-          "baseItem": 0
+          "subtotal": "average"
         }
       ],
       "rowItems": [


### PR DESCRIPTION
What
---

Omit the default `baseField: 0` and `baseItem: 0` properties in JSF, when parsing OOXML-default `baseField="0"` and `baseItem="0"` on `<dataField>`.

Why
---

So that the resulting JSF stays canonically minimal. Non-default values are preserved verbatim.

JSF stores non-default values; defaults are left implicit. The `baseField` and `baseItem` attributes default to `0` in OOXML, but Excel still writes the `0` explicitly on every `<dataField>`. That is just noise on the JSF side, so omit it.

Context: on a pivot `<dataField>`, the attributes `baseField` and `baseItem` select the comparison value used by base-item-relative `showDataAs` modes (`difference`, `percent`, `percentDiff`, `percentOfRunningTotal`, ...). Excel emits the literal `0` even when `showDataAs` doesn't reference a base item, so the values are unused.

grid-is/jsf2xlsx#222 is switching to unconditional emission of `baseField="0" baseItem="0"` (to match Excel) and that prompts this parser-side counterpart. The JSF → OOXML → JSF round-trip test in jsf2xlsx fails on the `pivot-table.json` fixture (whose dataFields carry neither attribute) when the parser hands back JSF with `baseField: 0` / `baseItem: 0` that the input didn't have. So omitting the defaults on parse keeps the round-trip stable.

How
---

Pass the default to `addProp`'s existing `skip` parameter: instead of
```ts
addProp(dataField, 'baseField', numAttr(df, 'baseField'))
```
do
```ts
`addProp(dataField, 'baseField', numAttr(df, 'baseField'), 0)`
```
... and same for `baseItem`.