### PR TITLE
Fix baseItem default: preserve baseItem="0"

### DIFF
--- a/src/handler/pivotTable.spec.ts
+++ b/src/handler/pivotTable.spec.ts
@@ -247,9 +247,9 @@ describe('handlerPivotTable', () => {
   });
 
   it('should parse data fields with subtotal, showDataAs, baseField/baseItem', () => {
-    // JSF stores non-default values; the OOXML-default `0` on
-    // `baseField`/`baseItem` is elided on parse. Non-default values still
-    // round-trip --- covered by the next test.
+    // `baseField` defaults to `0`, so the explicit `0` is elided. `baseItem="0"`
+    // is NOT the default (which is the `1048832` sentinel) --- it selects the
+    // first base item and is preserved.
     const xml = `<pivotTableDefinition name="PT1" cacheId="0">
       <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
       <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
@@ -264,14 +264,12 @@ describe('handlerPivotTable', () => {
       fieldIndex: 0,
       subtotal: 'sum',
       showDataAs: 'percentOfTotal',
+      baseItem: 0,
     });
     expect(pt.dataFields![0]).not.toHaveProperty('baseField');
-    expect(pt.dataFields![0]).not.toHaveProperty('baseItem');
   });
 
   it('should parse non-default baseField/baseItem verbatim', () => {
-    // Only the OOXML default value (`0`) is elided; explicit non-defaults
-    // are still preserved so they round-trip cleanly.
     const xml = `<pivotTableDefinition name="PT1" cacheId="0">
       <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
       <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
@@ -282,6 +280,19 @@ describe('handlerPivotTable', () => {
     </pivotTableDefinition>`;
     const pt = parse(xml)!;
     expect(pt.dataFields![0]).toMatchObject({ baseField: 2, baseItem: 3 });
+  });
+
+  it('should elide the baseItem "(not set)" sentinel (1048832)', () => {
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="1">
+        <dataField name="Sum" fld="0" subtotal="sum" baseItem="1048832"/>
+      </dataFields>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.dataFields![0]).not.toHaveProperty('baseItem');
   });
 
   it('should parse page fields with selectedItem', () => {

--- a/src/handler/pivotTables/parseDataFields.ts
+++ b/src/handler/pivotTables/parseDataFields.ts
@@ -6,6 +6,10 @@ import { parseEnum } from '../../utils/parseEnum.ts';
 import type { NumFmtLookup } from './NumFmtLookup.ts';
 import { resolveNumFmt } from './resolveNumFmt.ts';
 
+// OOXML default for `dataField/@baseItem` (CT_DataField): the "(not set)"
+// sentinel. Distinct from `0`, which selects the first base item.
+const BASE_ITEM_DEFAULT = 1048832;
+
 const DATA_FIELD_AGGREGATIONS: ReadonlySet<PivotDataFieldAggregation> =
   new Set<PivotDataFieldAggregation>([
     'average',
@@ -50,10 +54,13 @@ export function parseDataFields (root: Element, numFmts?: NumFmtLookup): PivotDa
     addProp(dataField, 'subtotal', parseEnum(attr(df, 'subtotal'), DATA_FIELD_AGGREGATIONS));
     addProp(dataField, 'showDataAs', parseEnum(attr(df, 'showDataAs'), SHOW_DATA_AS_VALUES));
     // JSF stores non-default values; defaults are implicit. `baseField`
-    // and `baseItem` default to `0` per OOXML, so the explicit `0` Excel
-    // emits is elided here to keep the parsed JSF canonically minimal.
+    // defaults to `0` per OOXML, so the explicit `0` Excel emits is elided.
+    // `baseItem` defaults to `1048832` (the "(not set)" sentinel), NOT `0` ---
+    // `baseItem="0"` means "relative to the first item" and is significant for
+    // the base-item-relative `showDataAs` modes (difference/percent/percentDiff),
+    // so it must be preserved; only the sentinel default is elided.
     addProp(dataField, 'baseField', numAttr(df, 'baseField'), 0);
-    addProp(dataField, 'baseItem', numAttr(df, 'baseItem'), 0);
+    addProp(dataField, 'baseItem', numAttr(df, 'baseItem'), BASE_ITEM_DEFAULT);
     addProp(dataField, 'numFmt', resolveNumFmt(df, numFmts));
     dataFields.push(dataField);
   }

--- a/tests/excel/pivot-table.xlsx.json
+++ b/tests/excel/pivot-table.xlsx.json
@@ -250,7 +250,8 @@
         {
           "fieldIndex": 3,
           "name": "Average of Salary",
-          "subtotal": "average"
+          "subtotal": "average",
+          "baseItem": 0
         }
       ],
       "rowItems": [


### PR DESCRIPTION
What
---

Stop omitting `dataField/@baseItem` when it is 0; omit it only when it is the sentinel value `1048832`.

(`baseField` is unaffected. Its OOXML default really is `0`.)

Why
---

The `baseItem` default is the 1048832 "(not set)" sentinel value, not 0. `baseItem="0"` selects the *first* base item.

Treating `0` as the default dropped meaningful information for the base-item-relative `showDataAs` modes (`difference`, `percent`, `percentDiff`): consumers saw no base item and fell back to raw aggregated values instead of the relative transform.

Verified in Excel:

- baseItem="1048832" renders identically to absent, and both differ from baseItem="0"

- On resave, Excel keeps baseItem="0" but omits the attribute for both the sentinel and absent cases