### PR TITLE
Parse x14 hideValuesRow from pivot extLst

### DIFF
--- a/src/handler/pivotTable.spec.ts
+++ b/src/handler/pivotTable.spec.ts
@@ -764,7 +764,42 @@ describe('handlerPivotTable', () => {
     ]);
   });
 
-  // extensions are no longer on PivotTable; extLst parsing was removed.
+  it('parses hideValuesRow from the x14 pivotTableDefinition extension', () => {
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="0"/>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="0"/>
+      <extLst>
+        <ext uri="{962EF5D1-5CA2-4c93-8EF4-DBF5C05439D2}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+          <x14:pivotTableDefinition hideValuesRow="1"/>
+        </ext>
+      </extLst>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.hideValuesRow).toBe(true);
+  });
+
+  it('omits hideValuesRow when the x14 extension is absent', () => {
+    const pt = parse(MINIMAL_PT)!;
+    expect(pt.hideValuesRow).toBeUndefined();
+  });
+
+  it('omits hideValuesRow when the x14 attribute is "0"', () => {
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="0"/>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="0"/>
+      <extLst>
+        <ext uri="{962EF5D1-5CA2-4c93-8EF4-DBF5C05439D2}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+          <x14:pivotTableDefinition hideValuesRow="0"/>
+        </ext>
+      </extLst>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.hideValuesRow).toBeUndefined();
+  });
 
   it('should omit calculatedFields when absent', () => {
     const pt = parse(MINIMAL_PT)!;

--- a/src/handler/pivotTable.ts
+++ b/src/handler/pivotTable.ts
@@ -5,6 +5,7 @@ import { attr, boolAttr, numAttr } from '../utils/attr.ts';
 import type { NumFmtLookup } from './pivotTables/NumFmtLookup.ts';
 import type { PivotTableWithOptionalCache } from './pivotTables/PivotTableWithOptionalCache.ts';
 import { parseDataFields } from './pivotTables/parseDataFields.ts';
+import { parseExtensions } from './pivotTables/parseExtensions.ts';
 import { parseFilters } from './pivotTables/parseFilters.ts';
 import { parsePageFields } from './pivotTables/parsePageFields.ts';
 import { parsePivotFields } from './pivotTables/parsePivotFields.ts';
@@ -167,6 +168,9 @@ export function handlerPivotTable (dom: Document, numFmts?: NumFmtLookup): Pivot
     }
   }
   if (calculatedFields.length > 0) { pt.calculatedFields = calculatedFields; }
+
+  // x14 pivotTableDefinition extension (e.g. hideValuesRow), carried in the table's <extLst>.
+  Object.assign(pt, parseExtensions(root));
 
   return pt;
 }

--- a/src/handler/pivotTables/parseExtensions.ts
+++ b/src/handler/pivotTables/parseExtensions.ts
@@ -1,0 +1,34 @@
+import type { Element } from '@borgar/simple-xml';
+import type { PivotTable } from '@jsfkit/types';
+import { boolAttr } from '../../utils/attr.ts';
+
+// URI of the x14 pivotTableDefinition extension (the 2009/9 SpreadsheetML
+// extension that carries post-2007 pivot attributes such as `hideValuesRow`).
+const X14_PIVOT_TABLE_DEFINITION_URI = '{962EF5D1-5CA2-4c93-8EF4-DBF5C05439D2}';
+
+/**
+ * Parse the `x14:pivotTableDefinition` extension from a pivot table's `<extLst>` into the
+ * JSF model. The extension lives in an `<ext>` keyed by {@link X14_PIVOT_TABLE_DEFINITION_URI}
+ * and carries pivot attributes that postdate the original CT_pivotTableDefinition schema.
+ *
+ * Only `hideValuesRow` is read for now. Other x14 pivot attributes
+ * (`calculatedMembersInFilters`, the deferred conditional-format containers, etc.) have no JSF
+ * representation yet; add them here once the model gains the corresponding properties.
+ *
+ * Returns a partial set of PivotTable properties to merge onto the table, or `undefined` when
+ * the extension is absent or carries nothing we model.
+ */
+export function parseExtensions (root: Element): Partial<PivotTable> | undefined {
+  // The element name `pivotTableDefinition` collides with the root, so scope to the ext URI
+  // first and read the (single) child rather than searching by tag name.
+  const ext = root
+    .getElementsByTagName('extLst')[0]
+    ?.children.find(e => e.getAttribute('uri') === X14_PIVOT_TABLE_DEFINITION_URI);
+  const x14 = ext?.children[0];
+
+  const hideValuesRow = x14 && boolAttr(x14, 'hideValuesRow');
+  // OOXML default is false; only convey the non-default value.
+  if (hideValuesRow) {
+    return { hideValuesRow: true };
+  }
+}

--- a/tests/excel/pivot-table.xlsx.json
+++ b/tests/excel/pivot-table.xlsx.json
@@ -318,6 +318,7 @@
       "indent": 0,
       "dataCaption": "Values",
       "uid": "{916D59D8-6143-8142-9B4B-F15BE71C47B7}",
+      "hideValuesRow": true,
       "cache": {
         "sourceType": "worksheet",
         "worksheetSource": { "type": "range", "ref": "A1:D16", "sheet": "Data" },


### PR DESCRIPTION
What
---

Parse the `hideValuesRow` attribute from the `x14:pivotTableDefinition` extension in a pivot table's `<extLst>` into the JSF model.

Why
---

So that the information is not lost, and round-trips from XLSX through JSF back to XLSX.