### PR TITLE
Parse xl/connections.xml into workbook.connections

### DIFF
--- a/src/convertBinary.ts
+++ b/src/convertBinary.ts
@@ -20,6 +20,7 @@ import { handlerComments } from './handler/comments.ts';
 import { handlerNotes } from './handler/notes.ts';
 import { handlerWorksheet } from './handler/worksheet.ts';
 import { handlerExternal } from './handler/external.ts';
+import { handlerConnections } from './handler/connections.ts';
 import { handlerTable } from './handler/table.ts';
 import { handlerPivotCacheDefinition } from './handler/pivotTables/pivotCacheDefinition.ts';
 import { handlerPivotCacheRecords } from './handler/pivotTables/pivotCacheRecords.ts';
@@ -197,6 +198,12 @@ export async function convertBinary (
   // copy external links in
   if (context.externalLinks.length) {
     wb.externals = context.externalLinks;
+  }
+
+  // data connections (xl/connections.xml) — the external sources pivot caches point at
+  const connections = await maybeRead(context, 'connections', handlerConnections, null);
+  if (connections?.length) {
+    wb.connections = connections;
   }
 
   // strings

--- a/src/handler/connections.spec.ts
+++ b/src/handler/connections.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseXML } from '@borgar/simple-xml';
+import { handlerConnections } from './connections.ts';
+
+describe('handlerConnections', () => {
+  it('parses a database connection with its dbPr', () => {
+    const xml = [
+      '<connections>',
+      '<connection id="1" xr16:uid="{UID}" sourceFile="C:\\src.xlsx" keepAlive="1"',
+      ' name="MyConn" type="5" refreshedVersion="8" background="1">',
+      '<dbPr connection="Provider=ACE" command="Sheet1$" commandType="3"/>',
+      '</connection>',
+      '</connections>',
+    ].join('');
+    expect(handlerConnections(parseXML(xml))).toEqual([ {
+      id: 1,
+      name: 'MyConn',
+      type: 5,
+      sourceFile: 'C:\\src.xlsx',
+      keepAlive: true,
+      background: true,
+      refreshedVersion: 8,
+      uid: '{UID}',
+      dbPr: { connection: 'Provider=ACE', command: 'Sheet1$', commandType: 3 },
+    } ]);
+  });
+
+  it('keeps a connection with no dbPr and skips one without an id', () => {
+    const xml = '<connections><connection id="2" name="Bare"/><connection name="NoId"/></connections>';
+    expect(handlerConnections(parseXML(xml))).toEqual([ { id: 2, name: 'Bare' } ]);
+  });
+});

--- a/src/handler/connections.ts
+++ b/src/handler/connections.ts
@@ -1,0 +1,73 @@
+import { type Document } from '@borgar/simple-xml';
+import { attr, boolAttr, numAttr } from '../utils/attr.ts';
+import type { Connection } from '@jsfkit/types';
+
+/**
+ * Parse `xl/connections.xml` into the workbook's data connections. Each `<connection>` is the
+ * external data source a pivot cache with `sourceType: 'external'` points at via its `connectionId`.
+ *
+ * Only the `<connection>` core attributes and the `<dbPr>` (database/file) child are read; other
+ * source children (`olapPr`, `webPr`, `textPr`) are not yet modelled, but such a connection still
+ * round-trips its attributes.
+ */
+export function handlerConnections (dom: Document): Connection[] {
+  const connections: Connection[] = [];
+  for (const el of dom.querySelectorAll('connections > connection')) {
+    const id = numAttr(el, 'id');
+    if (id == null) {
+      continue;
+    }
+    const conn: Connection = { id };
+    const name = attr(el, 'name');
+    if (name != null) {
+      conn.name = name;
+    }
+    const type = numAttr(el, 'type');
+    if (type != null) {
+      conn.type = type;
+    }
+    const sourceFile = attr(el, 'sourceFile');
+    if (sourceFile != null) {
+      conn.sourceFile = sourceFile;
+    }
+    const keepAlive = boolAttr(el, 'keepAlive');
+    if (keepAlive != null) {
+      conn.keepAlive = keepAlive;
+    }
+    const background = boolAttr(el, 'background');
+    if (background != null) {
+      conn.background = background;
+    }
+    const refreshedVersion = numAttr(el, 'refreshedVersion');
+    if (refreshedVersion != null) {
+      conn.refreshedVersion = refreshedVersion;
+    }
+    const uid = attr(el, 'xr16:uid');
+    if (uid != null) {
+      conn.uid = uid;
+    }
+    const dbPrEl = el.querySelectorAll('dbPr')[0];
+    if (dbPrEl) {
+      const dbPr: NonNullable<Connection['dbPr']> = {};
+      const connection = attr(dbPrEl, 'connection');
+      if (connection != null) {
+        dbPr.connection = connection;
+      }
+      const command = attr(dbPrEl, 'command');
+      if (command != null) {
+        dbPr.command = command;
+      }
+      const commandType = numAttr(dbPrEl, 'commandType');
+      if (commandType != null) {
+        dbPr.commandType = commandType;
+      }
+      const serverCommand = attr(dbPrEl, 'serverCommand');
+      if (serverCommand != null) {
+        dbPr.serverCommand = serverCommand;
+      }
+      conn.dbPr = dbPr;
+    }
+    connections.push(conn);
+  }
+  return connections;
+}


### PR DESCRIPTION
Read `xl/connections.xml` into the new `Workbook.connections`: each `<connection>`'s attributes and its `<dbPr>` child. Without this the connection is never parsed, so a workbook with an external-data pivot cache loses its connection on round-trip, leaving the cache's `connectionId` dangling.

Only `<dbPr>` is modelled; other source children (`olapPr`/`webPr`/`textPr`) are ignored for now, though their `<connection>` attributes still round-trip.

Depends on jsfkit/types#57 (the `Connection` type); typecheck stays red until that ships.
