### PR TITLE
fix: parse post-2010 showDataAs modes from the x14 dataField extension

### DIFF
--- a/src/handler/pivotTable.spec.ts
+++ b/src/handler/pivotTable.spec.ts
@@ -295,6 +295,72 @@ describe('handlerPivotTable', () => {
     expect(pt.dataFields![0]).not.toHaveProperty('baseItem');
   });
 
+  it('should parse post-2010 showDataAs from the x14 dataField extension', () => {
+    // `percentOfParent` and friends are illegal on the main `@showDataAs`
+    // attribute; Excel stores them in the x14 dataField extension as
+    // `pivotShowAs`. The base field stays on the main attribute.
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="1">
+        <dataField name="% of Parent" fld="0" baseField="1" baseItem="0">
+          <extLst>
+            <ext uri="{E15A36E0-9728-4e99-A89B-3F7291B0FE68}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+              <x14:dataField pivotShowAs="percentOfParent"/>
+            </ext>
+          </extLst>
+        </dataField>
+      </dataFields>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.dataFields![0]).toMatchObject({
+      name: '% of Parent',
+      fieldIndex: 0,
+      showDataAs: 'percentOfParent',
+      baseField: 1,
+      baseItem: 0,
+    });
+  });
+
+  it('should parse the rankDescending x14 showDataAs mode', () => {
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="1">
+        <dataField name="Rank" fld="0" baseField="2">
+          <extLst>
+            <ext uri="{E15A36E0-9728-4e99-A89B-3F7291B0FE68}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+              <x14:dataField pivotShowAs="rankDescending"/>
+            </ext>
+          </extLst>
+        </dataField>
+      </dataFields>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.dataFields![0].showDataAs).toBe('rankDescending');
+  });
+
+  it('should ignore an unknown pivotShowAs and fall back to the main attribute', () => {
+    const xml = `<pivotTableDefinition name="PT1" cacheId="0">
+      <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>
+      <pivotFields count="1"><pivotField dataField="1" showAll="1"/></pivotFields>
+      <rowFields count="0"/><colFields count="0"/>
+      <dataFields count="1">
+        <dataField name="Val" fld="0" showDataAs="percentOfTotal">
+          <extLst>
+            <ext uri="{E15A36E0-9728-4e99-A89B-3F7291B0FE68}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+              <x14:dataField pivotShowAs="bogusMode"/>
+            </ext>
+          </extLst>
+        </dataField>
+      </dataFields>
+    </pivotTableDefinition>`;
+    const pt = parse(xml)!;
+    expect(pt.dataFields![0].showDataAs).toBe('percentOfTotal');
+  });
+
   it('should parse page fields with selectedItem', () => {
     const xml = `<pivotTableDefinition name="PT1" cacheId="0">
       <location ref="A1" firstHeaderRow="1" firstDataRow="1" firstDataCol="0"/>

--- a/src/handler/pivotTables/parseDataFields.ts
+++ b/src/handler/pivotTables/parseDataFields.ts
@@ -10,6 +10,11 @@ import { resolveNumFmt } from './resolveNumFmt.ts';
 // sentinel. Distinct from `0`, which selects the first base item.
 const BASE_ITEM_DEFAULT = 1048832;
 
+// URI of the x14 dataField extension (CT_X14DataField, MS-XLSX). Excel strips
+// the post-2010 `showDataAs` modes from the main `dataField/@showDataAs`
+// attribute and stores them here instead, as `pivotShowAs`.
+const X14_DATA_FIELD_EXT_URI = '{E15A36E0-9728-4e99-A89B-3F7291B0FE68}';
+
 const DATA_FIELD_AGGREGATIONS: ReadonlySet<PivotDataFieldAggregation> =
   new Set<PivotDataFieldAggregation>([
     'average',
@@ -44,6 +49,25 @@ const SHOW_DATA_AS_VALUES: ReadonlySet<PivotShowDataAs> =
     'rankDescending',
   ]);
 
+/**
+ * Read the post-2010 `showDataAs` mode from a `<dataField>`'s x14 extension.
+ *
+ * The mode is carried as `pivotShowAs` on the `<x14:dataField>` child of the
+ * `<ext>` keyed by {@link X14_DATA_FIELD_EXT_URI} inside the field's `<extLst>`.
+ * Returns `undefined` when the extension is absent or its value is unknown, so
+ * callers fall back to the main `@showDataAs` attribute.
+ */
+function parsePivotShowAs (df: Element): PivotShowDataAs | undefined {
+  const ext = df
+    .getElementsByTagName('extLst')[0]
+    ?.children.find(e => e.getAttribute('uri') === X14_DATA_FIELD_EXT_URI);
+  const x14 = ext?.children[0];
+  if (!x14) {
+    return undefined;
+  }
+  return parseEnum(attr(x14, 'pivotShowAs'), SHOW_DATA_AS_VALUES);
+}
+
 export function parseDataFields (root: Element, numFmts?: NumFmtLookup): PivotDataField[] {
   const dataFields: PivotDataField[] = [];
   for (const df of root.querySelectorAll('dataFields > dataField')) {
@@ -52,7 +76,15 @@ export function parseDataFields (root: Element, numFmts?: NumFmtLookup): PivotDa
     };
     addProp(dataField, 'name', attr(df, 'name'));
     addProp(dataField, 'subtotal', parseEnum(attr(df, 'subtotal'), DATA_FIELD_AGGREGATIONS));
-    addProp(dataField, 'showDataAs', parseEnum(attr(df, 'showDataAs'), SHOW_DATA_AS_VALUES));
+    // Post-2010 `showDataAs` modes (`percentOfParent*`, `percentOfRunningTotal`,
+    // `rank*`) are not legal values of the main `@showDataAs` attribute; Excel
+    // carries them in the x14 dataField extension as `pivotShowAs`. When present,
+    // the extension value wins; otherwise fall back to the main attribute (which
+    // still holds the pre-2010 modes). The associated `baseField`/`baseItem` stay
+    // on the main attributes and are read below regardless of mode.
+    const showDataAs =
+      parsePivotShowAs(df) ?? parseEnum(attr(df, 'showDataAs'), SHOW_DATA_AS_VALUES);
+    addProp(dataField, 'showDataAs', showDataAs);
     // JSF stores non-default values; defaults are implicit. `baseField`
     // defaults to `0` per OOXML, so the explicit `0` Excel emits is elided.
     // `baseItem` defaults to `1048832` (the "(not set)" sentinel), NOT `0` ---


### PR DESCRIPTION
What
---

Parse the post-2010 "Show Values As" modes from the x14 `dataField` extension on pivot-table import.

The importer read `showDataAs` only from the main `dataField/@showDataAs` attribute. But the modes added in Excel 2010 — `percentOfParent`, `percentOfParentRow`, `percentOfParentCol`, `percentOfRunningTotal`, `rankAscending`, `rankDescending` — are not legal values of that attribute. Excel stores them instead in the x14 `dataField` extension as `pivotShowAs` (namespace `http://schemas.microsoft.com/office/spreadsheetml/2009/9/main`, URI `{E15A36E0-9728-4e99-A89B-3F7291B0FE68}`, inside the field's `<extLst>`). Since that extension was never parsed, those modes round-tripped to nothing and the field imported as a plain sum.

How
---

`parseDataFields` now reads each `<dataField>`'s x14 extension via a small `parsePivotShowAs` helper (mirroring the existing table-level `parseExtensions` lookup: locate the `<ext>` by URI in the field's `<extLst>`, then read `pivotShowAs` off its `<x14:dataField>` child). When the extension carries a valid mode it supplies `showDataAs` and wins over the main attribute; otherwise the main attribute is used as before, so the pre-2010 modes are unaffected. An unknown `pivotShowAs` is ignored (same `parseEnum` guard as elsewhere), falling back to the main attribute.

The associated `baseField`/`baseItem` are not in the extension — Excel keeps them on the main `dataField` attributes, which are already parsed — so no change was needed there.

Tests
---

Three parse tests: `percentOfParent` from the extension with `baseField`/`baseItem` captured from the main attributes; `rankDescending`; and an unknown `pivotShowAs` falling back to the main `@showDataAs`.
