### PR TITLE
Treat an external link part as ruling out a Google Sheets export

### DIFF
--- a/src/utils/isLikelyGSExport.spec.ts
+++ b/src/utils/isLikelyGSExport.spec.ts
@@ -1,0 +1,50 @@
+import { ZipArchive } from '@borgar/zip';
+import { describe, expect, test } from 'vitest';
+import { isLikelyGSExport } from './isLikelyGSExport.ts';
+
+/** An archive holding each of `paths`, with content that no signal looks at. */
+async function archiveOf (...paths: string[]) {
+  const zip = new ZipArchive();
+  for (const path of paths) {
+    await zip.write(path, '<x/>');
+  }
+  return zip;
+}
+
+describe('isLikelyGSExport', () => {
+  test('an archive with neither docProps part looks like a Google Sheets export', async () => {
+    expect(isLikelyGSExport(await archiveOf('xl/workbook.xml'))).toBe(true);
+  });
+
+  test('docProps/app.xml rules it out', async () => {
+    expect(isLikelyGSExport(await archiveOf('xl/workbook.xml', 'docProps/app.xml'))).toBe(false);
+  });
+
+  test('docProps/core.xml alone rules it out', async () => {
+    expect(isLikelyGSExport(await archiveOf('xl/workbook.xml', 'docProps/core.xml'))).toBe(false);
+  });
+
+  describe('external link parts', () => {
+    test('an external link part rules it out', async () => {
+      const zip = await archiveOf('xl/workbook.xml', 'xl/externalLinks/externalLink1.xml');
+      expect(isLikelyGSExport(zip)).toBe(false);
+    });
+
+    test('its relationship part alone rules it out', async () => {
+      // A malformed archive could carry the _rels entry without the part it describes; the
+      // directory's presence is the signal either way.
+      const zip = await archiveOf('xl/workbook.xml', 'xl/externalLinks/_rels/externalLink1.xml.rels');
+      expect(isLikelyGSExport(zip)).toBe(false);
+    });
+
+    test('the path is matched case-insensitively', async () => {
+      const zip = await archiveOf('xl/workbook.xml', 'xl/ExternalLinks/ExternalLink1.xml');
+      expect(isLikelyGSExport(zip)).toBe(false);
+    });
+
+    test('a similarly named part elsewhere does not rule it out', async () => {
+      const zip = await archiveOf('xl/workbook.xml', 'xl/worksheets/externalLinksNotes.xml');
+      expect(isLikelyGSExport(zip)).toBe(true);
+    });
+  });
+});

--- a/src/utils/isLikelyGSExport.ts
+++ b/src/utils/isLikelyGSExport.ts
@@ -10,21 +10,29 @@ import type { ZipArchive } from '@borgar/zip';
  * know the origin to avoid misinterpreting a legitimate string formula result
  * as an error.
  *
- * Signals checked (in order):
+ * Negative signals, each conclusive, checked in this order:
  *
- * 1. **`docProps/app.xml` present** → not Google Sheets. Excel and LibreOffice
- *    always write this file (containing `<Application>Microsoft Excel</Application>`
- *    or equivalent). Google Sheets never writes it. Validated against ~3,000 real
+ * 1. **`docProps/app.xml` present.** Excel and LibreOffice always write this
+ *    file (containing `<Application>Microsoft Excel</Application>` or
+ *    equivalent). Google Sheets never writes it. Validated against ~3,000 real
  *    XLSX files: 0 false negatives (no Google Sheets file writes app.xml),
- *    and the only "Google Sheets" files with app.xml were Excel-originated files
- *    uploaded to Google Sheets (which retain Excel's metadata and don't exhibit
- *    the `t="str"` error quirk).
+ *    and the only "Google Sheets" files with app.xml were Excel-originated
+ *    files uploaded to Google Sheets (which retain Excel's metadata and don't
+ *    exhibit the `t="str"` error quirk).
  *
- * 2. **Neither `docProps/app.xml` nor `docProps/core.xml`** → likely Google
- *    Sheets. Google Sheets writes neither. A rare third-party-generated XLSX
- *    might also lack both; treating it as Google Sheets is a safe false
- *    positive for this heuristic's purpose (the `t="str"` error conversion
- *    is unlikely to cause harm on synthetic files).
+ * 2. **`docProps/core.xml` present.** Google Sheets omits this too, so it
+ *    corroborates signal 1 without adding much on its own.
+ *
+ * 3. **An `xl/externalLinks/` part present.** Those parts cache the data behind
+ *    a cross-workbook reference such as `[Book1.xlsx]Sheet1!A1`, and Google
+ *    Sheets does not support such cross-workbook references. An Excel file
+ *    uploaded to Google Sheets and exported again might have them, but that is
+ *    already excluded by signal 1, since it keeps Excel's metadata.
+ *
+ * With none of them present, the file is taken to be a Google Sheets export. A
+ * rare third-party-generated XLSX might trip none of them either; treating it
+ * as Google Sheets is a safe false positive for this heuristic's purpose (the
+ * `t="str"` error conversion is unlikely to cause harm on synthetic files).
  */
 export function isLikelyGSExport (zip: ZipArchive): boolean {
   // The presence of docProps/app.xml is the strongest negative signal.
@@ -35,6 +43,10 @@ export function isLikelyGSExport (zip: ZipArchive): boolean {
   // Google Sheets also omits docProps/core.xml. Checking both gives extra
   // confidence, but app.xml alone is sufficient — core.xml just corroborates.
   if (zip.has('docProps/core.xml')) {
+    return false;
+  }
+  // External link parts are something Google Sheets has no way to produce.
+  if (zip.files.some(name => name.toLowerCase().startsWith('xl/externallinks/'))) {
     return false;
   }
   return true;


### PR DESCRIPTION
What
---

Add a third negative signal to `isLikelyGSExport`: any part under `xl/externalLinks/` rules out a Google Sheets export. Also add unit tests for the heuristic, covering all three signals.

Why
---

External link parts cache the data behind a cross-workbook reference such as `[Book1.xlsx]Sheet1!A1`, and Google Sheets cannot produce such references: it reaches other documents with `IMPORTRANGE`, which resolves server-side and exports as a plain value. An Excel-originated file uploaded to Google Sheets and exported again might retain them, but it keeps Excel's docProps, so the `docProps/app.xml` signal already excludes it.

Note
---

The new check matches case-insensitively (OPC part-name comparison is case-insensitive). The two docProps checks use `zip.has`, which matches part names case-sensitively; they should maybe be case-insensitive as well.